### PR TITLE
Enhance docs for manual container management and remote Docker host support

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -137,7 +137,10 @@ Environment variables can be set on the container for passing secrets or configu
 
 ## Manual container lifecycle management
 
-Instead of using `ExecutionContainer` as a context manager, you can also manually `run()` and `kill()` the container. This is useful for running the container on a separate host listening to a user-defined host port (e.g. `7777` in the example below).
+Instead of using `ExecutionContainer` as a context manager, you can also manually `run()` and `kill()` the container. Setting a user-defined port (e.g. `7777` in the example below) is optional.
+
+
+This is useful for running the container on a separate host listening to a user-defined host port (e.g. `7777` in the example below).
 
 ```python
 --8<-- "examples/08_manual_lifecycle.py:run-container"
@@ -150,3 +153,17 @@ Instead of using `ExecutionContainer` as a context manager, you can also manuall
 1. Create an `ExecutionContainer` instance using a fixed port.
 2. Run the container (detached).
 3. Cleanup.
+
+
+## Using a remote `DOCKER_HOST`
+
+If you want to run the execution container on a remote host but want to manage the container locally, you can set the `DOCKER_HOST` [environment variable](https://docs.docker.com/reference/cli/docker/#environment-variables) to the remote host. The following example assumes that the remote Docker daemon has been configured to accept `tcp` connections at port `2375`.
+
+```python
+--8<-- "examples/09_remote_docker_host.py:usage"
+```
+
+1. Example IP address of the remote Docker host
+2. Remote Docker daemon is accessible via `tcp` at port `2375`
+3. Creates a container on the remote host
+4. Create an IPython kernel in the remote container

--- a/examples/09_remote_docker_host.py
+++ b/examples/09_remote_docker_host.py
@@ -1,0 +1,20 @@
+import asyncio
+import os
+
+from ipybox import ExecutionClient, ExecutionContainer
+
+
+async def main():
+    # --8<-- [start:usage]
+    HOST = "192.168.94.50"  # (1)!
+    os.environ["DOCKER_HOST"] = f"tcp://{HOST}:2375"  # (2)!
+
+    async with ExecutionContainer(tag="ghcr.io/gradion-ai/ipybox:minimal") as container:  # (3)!
+        async with ExecutionClient(host=HOST, port=container.port) as client:  # (4)!
+            result = await client.execute("17 ** 0.13")
+            print(f"Output: {result.text}")
+    # --8<-- [end:usage]
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
- Clarified the optional nature of user-defined ports in the manual container lifecycle section.
- Added a new section on using a remote `DOCKER_HOST`, including an example script for managing containers on a remote Docker daemon.

closes #7