### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 
 `ipybox` is a lightweight and secure Python code execution sandbox based on [IPython](https://ipython.org/) and [Docker](https://www.docker.com/). You can run it locally on your computer or remotely in an environment of your choice. `ipybox` is designed for AI agents that need to execute code safely e.g. for data analytics use cases or executing code actions like in [`freeact`](https://github.com/gradion-ai/freeact/) agents.
 
+<a href="https://glama.ai/mcp/servers/@gradion-ai/ipybox">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@gradion-ai/ipybox/badge" alt="ipybox MCP server" />
+</a>
 
 <p align="center">
   <img src="docs/img/logo.png" alt="logo">


### PR DESCRIPTION
This PR adds a badge for the [ipybox](https://glama.ai/mcp/servers/@gradion-ai/ipybox) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@gradion-ai/ipybox">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@gradion-ai/ipybox/badge" alt="ipybox MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.