### PR TITLE
Add configurable kernel working directory behavior

### DIFF
--- a/docs/codeexec.md
+++ b/docs/codeexec.md
@@ -81,8 +81,18 @@ This also stops any MCP servers started during execution. They restart lazily on
 
 ## Working directory
 
-The kernel shares the working directory with the parent process:
+If `working_dir` is set, the kernel starts there and ipybox restores that
+directory after each execution. When a reset happens, ipybox prints a message
+in the cell output.
 
 ```python
---8<-- "examples/codexec.py:working_directory"
+--8<-- "examples/codexec.py:working_directory_reset"
+```
+
+If `working_dir` is not set, ipybox preserves the default IPython behavior:
+code can change the current working directory and that change persists until
+code changes it again or the kernel is reset.
+
+```python
+--8<-- "examples/codexec.py:working_directory_persistent"
 ```

--- a/examples/codexec.py
+++ b/examples/codexec.py
@@ -116,14 +116,29 @@ async def kernel_reset():
     # --8<-- [end:kernel_reset]
 
 
-async def working_directory():
-    # --8<-- [start:working_directory]
-    async with CodeExecutor() as executor:
-        import os
+async def working_directory_reset():
+    # --8<-- [start:working_directory_reset]
+    base_dir = Path.cwd()
 
-        result = await executor.execute("import os; print(os.getcwd())")
-        assert result.text == os.getcwd()
-    # --8<-- [end:working_directory]
+    with tempfile.TemporaryDirectory() as changed_dir:
+        async with CodeExecutor(working_dir=base_dir) as executor:
+            result = await executor.execute(f"import os; os.chdir({changed_dir!r})")
+            assert result.text == f"[ipybox] cwd reset to {base_dir}"
+
+            result = await executor.execute("import os; print(os.getcwd())")
+            assert result.text == str(base_dir)
+    # --8<-- [end:working_directory_reset]
+
+
+async def working_directory_persistent():
+    # --8<-- [start:working_directory_persistent]
+    with tempfile.TemporaryDirectory() as changed_dir:
+        async with CodeExecutor() as executor:
+            await executor.execute(f"import os; os.chdir({changed_dir!r})")
+
+            result = await executor.execute("import os; print(os.getcwd())")
+            assert result.text == changed_dir
+    # --8<-- [end:working_directory_persistent]
 
 
 async def main():
@@ -134,7 +149,8 @@ async def main():
     await custom_timeouts()
     await kernel_environment()
     await kernel_reset()
-    await working_directory()
+    await working_directory_reset()
+    await working_directory_persistent()
 
 
 if __name__ == "__main__":

--- a/ipybox/code_exec.py
+++ b/ipybox/code_exec.py
@@ -99,6 +99,7 @@ class CodeExecutor:
         kernel_gateway_host: str = "localhost",
         kernel_gateway_port: int | None = None,
         kernel_env: dict[str, str] | None = None,
+        working_dir: Path | None = None,
         images_dir: Path | None = None,
         approval_timeout: float | None = None,
         connect_timeout: float = 30,
@@ -119,6 +120,10 @@ class CodeExecutor:
             kernel_env: Environment variables to set for the IPython kernel.
                 Kernels do not inherit environment variables from the parent
                 process.
+            working_dir: Working directory for the kernel gateway and IPython
+                kernel. If set, ipybox restores the kernel to this directory
+                after each execution. If `None`, cwd changes persist until code
+                changes them again or the kernel is reset.
             images_dir: Directory for saving images generated during code
                 execution. Defaults to `images` in the current directory.
             approval_timeout: Timeout in seconds for approval requests. If an
@@ -140,6 +145,7 @@ class CodeExecutor:
 
         self.kernel_gateway_host = kernel_gateway_host
         self.kernel_gateway_port = kernel_gateway_port or find_free_port()
+        self.working_dir = working_dir.resolve() if working_dir is not None else None
         self.kernel_env = kernel_env or {}
         self.images_dir = images_dir
 
@@ -332,6 +338,7 @@ class CodeExecutor:
             async with KernelGateway(
                 host=self.kernel_gateway_host,
                 port=self.kernel_gateway_port,
+                working_dir=self.working_dir,
                 sandbox=self.sandbox,
                 sandbox_config=self.sandbox_config,
                 log_level=self.log_level,
@@ -344,6 +351,7 @@ class CodeExecutor:
                 async with KernelClient(
                     host=self.kernel_gateway_host,
                     port=self.kernel_gateway_port,
+                    working_dir=self.working_dir,
                     images_dir=self.images_dir,
                 ) as client:
                     yield client

--- a/ipybox/kernel_mgr/client.py
+++ b/ipybox/kernel_mgr/client.py
@@ -3,6 +3,7 @@ import logging
 import time
 from base64 import b64decode
 from dataclasses import dataclass
+from inspect import cleandoc
 from pathlib import Path
 from typing import AsyncIterator
 from uuid import uuid4
@@ -64,6 +65,7 @@ class KernelClient:
         self,
         host: str = "localhost",
         port: int = 8888,
+        working_dir: Path | None = None,
         images_dir: Path | None = None,
         ping_interval: float = 10,
     ):
@@ -71,6 +73,9 @@ class KernelClient:
         Args:
             host: Hostname or IP address of the kernel gateway.
             port: Port number of the kernel gateway.
+            working_dir: Working directory to set in the IPython kernel and
+                restore after each cell execution. If `None`, ipybox leaves the
+                kernel working directory unchanged between executions.
             images_dir: Directory for saving images generated during code
                 execution. Defaults to `images` in the current directory.
             ping_interval: Interval in seconds for WebSocket pings that
@@ -78,6 +83,7 @@ class KernelClient:
         """
         self.host = host
         self.port = port
+        self.working_dir = working_dir.resolve() if working_dir is not None else None
 
         self.images_dir = images_dir or Path("images")
         self.ping_interval = ping_interval
@@ -349,14 +355,44 @@ class KernelClient:
         await self.drain(timeout=drain_timeout)
 
     async def _init_kernel(self):
+        init_parts = [
+            cleandoc("""
+                import os as _os
+                %colors nocolor
+                for _k in ('CLICOLOR', 'CLICOLOR_FORCE', 'FORCE_COLOR'):
+                    _os.environ.pop(_k, None)
+            """)
+        ]
+
+        if self.working_dir is not None:
+            working_dir = str(self.working_dir)
+            init_parts.append(
+                cleandoc(f"""
+                    _ipybox_cwd = {working_dir!r}
+                    _os.chdir(_ipybox_cwd)
+                    def _ipybox_restore_cwd(_result=None, _cwd=_ipybox_cwd, _os=_os):
+                        try:
+                            _current_cwd = _os.getcwd()
+                        except FileNotFoundError:
+                            _current_cwd = None
+                        if _current_cwd != _cwd:
+                            _os.chdir(_cwd)
+                            print(f'[ipybox] cwd reset to {{_cwd}}')
+                    get_ipython().events.register('post_run_cell', _ipybox_restore_cwd)
+                    del _ipybox_cwd, _ipybox_restore_cwd
+                """)
+            )
+
+        init_parts.append(
+            cleandoc("""
+                _os.environ['TERM'] = 'dumb'
+                _os.environ['NO_COLOR'] = '1'
+                del _os, _k
+            """)
+        )
+
         await self.execute(
-            "import os as _os\n"
-            "%colors nocolor\n"
-            "for _k in ('CLICOLOR', 'CLICOLOR_FORCE', 'FORCE_COLOR'):\n"
-            "    _os.environ.pop(_k, None)\n"
-            "_os.environ['TERM'] = 'dumb'\n"
-            "_os.environ['NO_COLOR'] = '1'\n"
-            "del _os, _k",
+            "\n".join(init_parts),
             timeout=10,
         )
 

--- a/ipybox/kernel_mgr/server.py
+++ b/ipybox/kernel_mgr/server.py
@@ -3,6 +3,7 @@ import asyncio
 import os
 import sys
 from pathlib import Path
+from typing import IO, Any
 
 import psutil
 
@@ -31,6 +32,7 @@ class KernelGateway:
         self,
         host: str = "localhost",
         port: int = 8888,
+        working_dir: Path | None = None,
         sandbox: bool = False,
         sandbox_config: Path | None = None,
         log_level: str = "INFO",
@@ -41,6 +43,8 @@ class KernelGateway:
         Args:
             host: Hostname or IP address to bind the gateway to.
             port: Port number the gateway listens on.
+            working_dir: Working directory for the kernel gateway process.
+                If `None`, inherit the current process working directory.
             sandbox: Whether to run the gateway inside the sandbox-runtime.
             sandbox_config: Path to a JSON file with sandbox configuration.
                 See the Configuration section of the
@@ -54,6 +58,7 @@ class KernelGateway:
         """
         self.host = host
         self.port = port
+        self.working_dir = working_dir.resolve() if working_dir is not None else None
 
         self.sandbox = sandbox
         self.sandbox_config = sandbox_config
@@ -100,12 +105,24 @@ class KernelGateway:
         process_env = {"PATH": os.environ.get("PATH", "")}
         process_env.update(self.env)
 
-        self._process = await asyncio.create_subprocess_exec(
-            *cmd,
-            env=process_env,
-            stdout=sys.stderr if self.log_to_stderr else asyncio.subprocess.DEVNULL,
-            stderr=sys.stderr if self.log_to_stderr else asyncio.subprocess.DEVNULL,
-        )
+        stdout: int | IO[Any] | None = sys.stderr if self.log_to_stderr else asyncio.subprocess.DEVNULL
+        stderr: int | IO[Any] | None = sys.stderr if self.log_to_stderr else asyncio.subprocess.DEVNULL
+
+        if self.working_dir is not None:
+            self._process = await asyncio.create_subprocess_exec(
+                *cmd,
+                cwd=self.working_dir,
+                env=process_env,
+                stdout=stdout,
+                stderr=stderr,
+            )
+        else:
+            self._process = await asyncio.create_subprocess_exec(
+                *cmd,
+                env=process_env,
+                stdout=stdout,
+                stderr=stderr,
+            )
 
     async def stop(self, timeout: float = 10):
         """Stops the kernel gateway process.

--- a/tests/integration/test_code_exec.py
+++ b/tests/integration/test_code_exec.py
@@ -123,6 +123,33 @@ for i in range(3):
 
         assert "0.20s" in str(exc_info.value)
 
+    @pytest.mark.asyncio
+    async def test_explicit_working_dir(self, tmp_path: Path):
+        """Test CodeExecutor starts and restores the kernel in working_dir."""
+        async with CodeExecutor(
+            kernel_env={"PYTHONPATH": str(tmp_path)},
+            working_dir=tmp_path,
+            log_level="ERROR",
+        ) as executor:
+            result = await executor.execute("import os; print(os.getcwd())")
+            assert result.text == str(tmp_path.resolve())
+
+            await executor.execute("import os; os.chdir('/')")
+
+            result = await executor.execute("import os; print(os.getcwd())")
+            assert result.text == str(tmp_path.resolve())
+
+    @pytest.mark.asyncio
+    async def test_explicit_working_dir_prints_reset_message(self, tmp_path: Path):
+        """Test CodeExecutor prints the reset message when working_dir is set."""
+        async with CodeExecutor(
+            kernel_env={"PYTHONPATH": str(tmp_path)},
+            working_dir=tmp_path,
+            log_level="ERROR",
+        ) as executor:
+            result = await executor.execute("import os; os.chdir('/')")
+            assert result.text == f"[ipybox] cwd reset to {tmp_path.resolve()}"
+
 
 class TestMcpToolExecution:
     """Core integration: kernel code calling MCP tools through approval."""

--- a/tests/integration/test_kernel_init.py
+++ b/tests/integration/test_kernel_init.py
@@ -31,6 +31,17 @@ async def client(gateway, tmp_path):
         yield c
 
 
+@pytest_asyncio.fixture
+async def client_with_working_dir(gateway, tmp_path):
+    async with KernelClient(
+        host=gateway.host,
+        port=gateway.port,
+        working_dir=tmp_path,
+        images_dir=tmp_path / "images",
+    ) as c:
+        yield c
+
+
 class TestKernelInitialization:
     @pytest.mark.asyncio
     async def test_traceback_no_ansi(self, client: KernelClient):
@@ -57,4 +68,11 @@ class TestKernelInitialization:
         for name in ("_os", "_k", "_ipybox_cwd", "_ipybox_restore_cwd"):
             with pytest.raises(ExecutionError) as exc_info:
                 await client.execute(f"print({name})")
+            assert "NameError" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_init_does_not_leak_hook_variables_with_working_dir(self, client_with_working_dir: KernelClient):
+        for name in ("_os", "_k", "_ipybox_cwd", "_ipybox_restore_cwd"):
+            with pytest.raises(ExecutionError) as exc_info:
+                await client_with_working_dir.execute(f"print({name})")
             assert "NameError" in str(exc_info.value)

--- a/tests/integration/test_kernel_init.py
+++ b/tests/integration/test_kernel_init.py
@@ -1,4 +1,4 @@
-"""Test that _init_kernel suppresses colored output."""
+"""Tests for kernel initialization behavior."""
 
 import re
 
@@ -31,7 +31,7 @@ async def client(gateway, tmp_path):
         yield c
 
 
-class TestNoColorOutput:
+class TestKernelInitialization:
     @pytest.mark.asyncio
     async def test_traceback_no_ansi(self, client: KernelClient):
         with pytest.raises(ExecutionError) as exc_info:
@@ -54,10 +54,7 @@ class TestNoColorOutput:
 
     @pytest.mark.asyncio
     async def test_init_does_not_leak_variables(self, client: KernelClient):
-        with pytest.raises(ExecutionError) as exc_info:
-            await client.execute("print(_os)")
-        assert "NameError" in str(exc_info.value)
-
-        with pytest.raises(ExecutionError) as exc_info:
-            await client.execute("print(_k)")
-        assert "NameError" in str(exc_info.value)
+        for name in ("_os", "_k", "_ipybox_cwd", "_ipybox_restore_cwd"):
+            with pytest.raises(ExecutionError) as exc_info:
+                await client.execute(f"print({name})")
+            assert "NameError" in str(exc_info.value)

--- a/tests/integration/test_kernel_mgr.py
+++ b/tests/integration/test_kernel_mgr.py
@@ -268,6 +268,51 @@ class TestStatePersistence:
         assert "NameError" in str(exc_info.value)
 
 
+class TestWorkingDirectory:
+    """Tests for working directory behavior across executions."""
+
+    @pytest.mark.asyncio
+    async def test_os_chdir_persists_without_working_dir(self, kernel_client: KernelClient, tmp_path: Path):
+        """Test os.chdir changes persist when no working_dir is configured."""
+        await kernel_client.execute(f"import os; os.chdir({str(tmp_path)!r})")
+
+        result = await kernel_client.execute("import os; print(os.getcwd())")
+        assert result.text == str(tmp_path.resolve())
+
+    @pytest.mark.asyncio
+    async def test_cd_magic_persists_without_working_dir(self, kernel_client: KernelClient, tmp_path: Path):
+        """Test %cd changes persist when no working_dir is configured."""
+        await kernel_client.execute(f"%cd {tmp_path}")
+
+        result = await kernel_client.execute("import os; print(os.getcwd())")
+        assert result.text == str(tmp_path.resolve())
+
+    @pytest.mark.asyncio
+    async def test_explicit_working_dir_overrides_gateway_start_dir(self, kernel_gateway, tmp_path: Path):
+        """Test KernelClient can enforce an explicit working directory."""
+        async with KernelClient(
+            host=kernel_gateway.host,
+            port=kernel_gateway.port,
+            working_dir=tmp_path,
+        ) as client:
+            result = await client.execute("import os; print(os.getcwd())")
+            assert result.text == str(tmp_path.resolve())
+
+    @pytest.mark.asyncio
+    async def test_explicit_working_dir_resets_and_prints_message(self, kernel_gateway, tmp_path: Path):
+        """Test explicit working_dir restores cwd and prints the reset message."""
+        async with KernelClient(
+            host=kernel_gateway.host,
+            port=kernel_gateway.port,
+            working_dir=tmp_path,
+        ) as client:
+            result = await client.execute("import os; os.chdir('/')")
+            assert result.text == f"[ipybox] cwd reset to {tmp_path.resolve()}"
+
+            result = await client.execute("import os; print(os.getcwd())")
+            assert result.text == str(tmp_path.resolve())
+
+
 class TestImageGeneration:
     """Tests for matplotlib image generation."""
 

--- a/tests/unit/test_kernel_gateway.py
+++ b/tests/unit/test_kernel_gateway.py
@@ -24,3 +24,22 @@ async def test_start_discards_stdio_when_log_to_stderr_disabled(monkeypatch: pyt
     assert isinstance(kwargs, dict)
     assert kwargs["stdout"] is asyncio.subprocess.DEVNULL
     assert kwargs["stderr"] is asyncio.subprocess.DEVNULL
+
+
+@pytest.mark.asyncio
+async def test_start_uses_configured_working_dir(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_create_subprocess_exec(*cmd: object, **kwargs: object) -> SimpleNamespace:
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(returncode=0, pid=123)
+
+    monkeypatch.setattr("ipybox.kernel_mgr.server.asyncio.create_subprocess_exec", fake_create_subprocess_exec)
+
+    gateway = KernelGateway(host="127.0.0.1", port=9999, working_dir=tmp_path, log_level="ERROR")
+    await gateway.start()
+
+    kwargs = captured["kwargs"]
+    assert isinstance(kwargs, dict)
+    assert kwargs["cwd"] == tmp_path.resolve()


### PR DESCRIPTION
## Summary
- add an optional `working_dir` to `CodeExecutor`, `KernelGateway`, and `KernelClient`
- restore the kernel cwd only when `working_dir` is configured, and emit a reset message when the hook runs
- document and test both the reset and persistent working-directory behaviors