### PR TITLE
Add SECURITY.md — enable private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it
+responsibly through **GitHub Private Vulnerability Reporting (PVR)**.
+
+**To report**: Go to the [Security Advisories page](../../security/advisories/new)
+and submit a new advisory.
+
+**To enable PVR** (maintainers): Settings → Code security → Private vulnerability reporting → Enable.
+
+Please **do not** open public issues for security vulnerabilities.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,6 +8,4 @@ responsibly through **GitHub Private Vulnerability Reporting (PVR)**.
 **To report**: Go to the [Security Advisories page](../../security/advisories/new)
 and submit a new advisory.
 
-**To enable PVR** (maintainers): Settings → Code security → Private vulnerability reporting → Enable.
-
 Please **do not** open public issues for security vulnerabilities.


### PR DESCRIPTION
## Summary

Add `SECURITY.md` with instructions for responsible vulnerability disclosure via [GitHub Private Vulnerability Reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability) (PVR).

PVR allows security researchers to report vulnerabilities privately through GitHub, keeping details confidential until a fix is ready. As a CNA, GitHub can assign CVE IDs directly through this workflow.