### PR TITLE
Add %%bash/%%sh cell magic approval support

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,13 +2,15 @@
 
 [`CodeExecutor`][ipybox.CodeExecutor] coordinates three components: an IPython kernel for stateful execution of Python code and shell commands, a tool server for MCP tool dispatch, and an approval channel for application-level approval of tool calls and shell commands.
 
-The application submits code to `CodeExecutor`, which forwards it to an IPython kernel running inside an optional sandbox. Shell commands use IPython's `!` syntax and mix freely with Python code in a single block. When code calls a [generated](apigen.md) Python tool API function, the request routes to the tool server, which manages local (stdio) MCP servers and connections to remote (HTTP) MCP servers.
+The application submits code to `CodeExecutor`, which forwards it to an IPython kernel running inside an optional sandbox. Inline shell commands use IPython's `!` syntax[^1] and mix freely with Python code in a single block. When code calls a [generated](apigen.md) Python tool API function, the request routes to the tool server, which manages local (stdio) MCP servers and connections to remote (HTTP) MCP servers.
 
 Before executing any tool call, the tool server sends an approval request back through `CodeExecutor` to the application, blocking until it accepts or rejects. Shell commands go through the same approval channel when shell command approval is enabled. MCP tool execution runs outside the kernel sandbox in the tool server. Shell commands execute as kernel subprocesses inside the sandbox when enabled.
 
 !!! info "mcpygen"
 
     The code generation and tool execution infrastructure is provided by [mcpygen](https://gradion-ai.github.io/mcpygen/) and re-exported by ipybox.
+
+[^1]: `%%bash`/`%%sh` cell magics are also supported and run an entire code block as a shell script.
 
 <figure markdown>
   ![Architecture](images/architecture-dark.png){ width="100%" }

--- a/docs/codeexec.md
+++ b/docs/codeexec.md
@@ -26,6 +26,16 @@ Shell commands use IPython's `!` syntax:
 
 `!cmd` runs a shell command and prints its output. `result = !cmd` captures the output as a list of lines. Python variables are interpolated into shell commands via `{variable}` syntax. Shell commands and Python code mix freely in a single code block, for example to install packages with `!pip install` and use them immediately.
 
+## Cell magics
+
+For multi-line shell scripts, use `%%bash` or `%%sh` cell magics:
+
+```python
+--8<-- "examples/codexec.py:bash_magic"
+```
+
+`%%bash` must be the first line of the code block and passes the remaining lines to bash as a script. `%%sh` works the same way with `sh`. Unlike `!cmd`, cell magics cannot be mixed with Python code and do not support Python variable interpolation.
+
 ## Tool calls
 
 ipybox can [generate typed Python APIs](apigen.md) from MCP server tool schemas. The generated code executes within the kernel, while MCP servers run on a separate [tool server](architecture.md).
@@ -54,15 +64,21 @@ Enable `approve_shell_cmds=True` to require application-level approval for shell
 
 Each `!cmd` triggers an `ApprovalRequest` with `tool_name="shell"` and `tool_args={"cmd": "..."}`, using the same approval interface as tool calls. Variable interpolation happens before the approval request, so the application sees the fully expanded command.
 
+`%%bash` and `%%sh` cell magics also trigger approval when `approve_shell_cmds=True`. The `tool_args["cmd"]` contains the cell body:
+
+```python
+--8<-- "examples/codexec.py:bash_magic_approval"
+```
+
 #### Preventing bypass
 
-Code could bypass shell command approval through various process-creation APIs (`subprocess`, `os.system()`, `os.exec*()`, `os.spawn*()`, `os.posix_spawn()`, `pty.spawn()`). Set `require_shell_escape=True` to guard these, forcing all shell execution through the `!` syntax where it triggers the approval flow:
+Code could bypass shell command approval through various process-creation APIs (`subprocess`, `os.system()`, `os.exec*()`, `os.spawn*()`, `os.posix_spawn()`, `pty.spawn()`). Set `require_shell_escape=True` to guard these, forcing all shell execution through `!cmd` or `%%bash`/`%%sh` where it triggers the approval flow:
 
 ```python
 --8<-- "examples/codexec.py:subprocess_blocking"
 ```
 
-With `require_shell_escape=True`, direct process-creation calls raise a `RuntimeError`. Shell commands via `!cmd` still work and go through the approval channel. Requires `approve_shell_cmds=True`.
+With `require_shell_escape=True`, direct process-creation calls raise a `RuntimeError`. Shell commands via `!cmd` and `%%bash`/`%%sh` still work and go through the approval channel. Requires `approve_shell_cmds=True`.
 
 !!! note
     These guards are Python-level guards that close the most obvious gaps. They catch accidental bypass (e.g., an LLM agent reaching for `subprocess.run`) but are not a security boundary: code running in the kernel can undo guards, call C functions via `ctypes`, or use CPython internal modules. These bypasses can be prevented at the OS level. A future version will add [sandbox](sandbox.md)-level enforcement for shell command approval.

--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -14,7 +14,7 @@ The published architecture overview is in `docs/architecture.md`.
 ## CodeExecutor Parameters
 
 - `approve_tool_calls` (default `True`): requires approval for MCP tool calls via `stream()`
-- `approve_shell_cmds` (default `False`): requires approval for `!cmd` shell commands
+- `approve_shell_cmds` (default `False`): requires approval for `!cmd` shell commands and `%%bash`/`%%sh` cell magics
 - `require_shell_escape` (default `False`): blocks direct `subprocess`/`os.system()` calls, forcing through `!` approval; requires `approve_shell_cmds=True`
 
 ## mcpygen Dependency
@@ -39,7 +39,7 @@ The following modules have been extracted to the [mcpygen](https://github.com/gr
 5. If accepted: ToolServer executes the MCP tool on the MCP server
 6. Result returned by generated wrapper function
 
-### Shell commands
+### Shell commands (`!cmd`)
 
 1. `!cmd` in IPython triggers custom handler installed by `build_init_code()`
 2. Handler -> `ApprovalRequestor` -> ToolServer -> `ApprovalClient`
@@ -47,9 +47,17 @@ The following modules have been extracted to the [mcpygen](https://github.com/gr
 4. If accepted: handler executes original shell command
 5. `require_shell_escape=True`: `ContextVar` guard blocks direct process-creation calls (`subprocess.Popen`, `os.system`, `os.exec*`, `os.spawn*`, `os.posix_spawn*`, `pty.spawn`), temporarily lifted during handler execution
 
+### Cell magics (`%%bash`/`%%sh`)
+
+1. `%%bash` or `%%sh` triggers magic wrapper installed by `build_init_code()`
+2. Wrapper -> `ApprovalRequestor` -> ToolServer -> `ApprovalClient`
+3. Application receives `ApprovalRequest(tool_name="shell", tool_args={"cmd": "<cell body>"})`
+4. If accepted: wrapper calls original magic, which runs the script via `asyncio.create_subprocess_exec` on a background thread
+5. `require_shell_escape=True`: a `threading.Event` (`_ipybox_magic_allowed`) is used instead of `ContextVar` because IPython 9.x runs the subprocess on a background thread where `ContextVar` does not propagate. The event is set before calling the original magic and cleared in a `finally` block. Subprocess guards check both the `ContextVar` and the event.
+
 ## Kernel Initialization
 
-`build_init_code()` composes optional init sections: env setup, cwd restore hook, shell approval handlers, subprocess guards. All internals use `_ipybox_` prefix, cleaned up after init. `KernelClient._rewrite_traceback()` hides these from error output.
+`build_init_code()` composes optional init sections: env setup, cwd restore hook, shell approval handlers, bash magic handlers, subprocess guards. All internals use `_ipybox_` prefix, cleaned up after init. `KernelClient._rewrite_traceback()` hides these from error output.
 
 ## Code Generation
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,7 +16,7 @@ pip install ipybox
 --8<-- "examples/quickstart.py:basic_execution"
 ```
 
-Shell commands use IPython's `!` syntax and mix freely with Python code. `result = !cmd` captures shell output into a Python variable. Python variables are interpolated into shell commands via `{variable}` syntax.
+Shell commands use IPython's `!` syntax and mix freely with Python code. `result = !cmd` captures shell output into a Python variable. Python variables are interpolated into shell commands via `{variable}` syntax. For multi-line shell scripts, use `%%bash` or `%%sh` cell magics.
 
 ## Programmatic MCP tool calling
 
@@ -60,7 +60,7 @@ The generated API can then be imported and called in code submitted to `execute(
 
 ## Approval
 
-Both MCP tool calls and shell commands can require application-level approval before execution. `approve_tool_calls` (default `True`) requires approval for MCP tool calls. `approve_shell_cmds` (default `False`) requires approval for shell commands.
+Both MCP tool calls and shell commands can require application-level approval before execution. `approve_tool_calls` (default `True`) requires approval for MCP tool calls. `approve_shell_cmds` (default `False`) requires approval for `!cmd` shell commands and `%%bash`/`%%sh` cell magics.
 
 The following example executes a code block that calls an MCP tool and runs a shell command, both requiring approval:
 

--- a/examples/codexec.py
+++ b/examples/codexec.py
@@ -165,6 +165,39 @@ async def shell_commands():
     # --8<-- [end:shell_commands]
 
 
+async def bash_magic():
+    # --8<-- [start:bash_magic]
+    code = """
+    %%bash
+    for i in 1 2 3; do
+      echo $i
+    done
+    """
+
+    async with CodeExecutor() as executor:
+        result = await executor.execute(code)
+        assert result.text == "1\n2\n3"
+    # --8<-- [end:bash_magic]
+
+
+async def bash_magic_approval():
+    # --8<-- [start:bash_magic_approval]
+    code = """
+    %%bash
+    echo hello from bash
+    """
+
+    async with CodeExecutor(approve_shell_cmds=True) as executor:
+        async for item in executor.stream(code):
+            match item:
+                case ApprovalRequest(tool_name="shell", tool_args=args):
+                    assert "echo hello from bash" in args["cmd"]
+                    await item.accept()
+                case CodeExecutionResult():
+                    assert item.text == "hello from bash"
+    # --8<-- [end:bash_magic_approval]
+
+
 async def shell_approval():
     # --8<-- [start:shell_approval]
     code = """
@@ -212,6 +245,8 @@ async def main():
     await working_directory_reset()
     await working_directory_persistent()
     await shell_commands()
+    await bash_magic()
+    await bash_magic_approval()
     await shell_approval()
     await subprocess_blocking()
 

--- a/ipybox/code_exec.py
+++ b/ipybox/code_exec.py
@@ -146,8 +146,9 @@ class CodeExecutor:
                 before execution. When `True`, each tool call yields an
                 `ApprovalRequest` that must be accepted or rejected.
             approve_shell_cmds: Whether to require approval for `!` shell
-                commands. When enabled, each shell command triggers an
-                `ApprovalRequest` before execution.
+                commands and `%%bash`/`%%sh` cell magics. When enabled,
+                each shell command triggers an `ApprovalRequest` before
+                execution.
             require_shell_escape: Whether to block direct process-creation
                 calls (`subprocess`, `os.system`, `os.exec*`, `os.spawn*`,
                 `os.posix_spawn*`, `pty.spawn`), forcing shell commands

--- a/ipybox/kernel_mgr/client.py
+++ b/ipybox/kernel_mgr/client.py
@@ -405,5 +405,10 @@ class KernelClient:
             if "_ipybox_" in entry:
                 continue
             entry = re.sub(r"get_ipython\(\)\.(?:system|getoutput)\(['\"](.+?)['\"]\)", r"!\1", entry)
+            entry = re.sub(
+                r"get_ipython\(\)\.run_cell_magic\(['\"](\w+)['\"],\s*['\"][^'\"]*['\"],\s*['\"](.+?)['\"]\)",
+                r"%%\1\n\2",
+                entry,
+            )
             result.append(entry)
         return result

--- a/ipybox/kernel_mgr/client.py
+++ b/ipybox/kernel_mgr/client.py
@@ -87,12 +87,14 @@ class KernelClient:
             ping_interval: Interval in seconds for WebSocket pings that
                 keep the connection to the IPython kernel alive.
             approve_shell_cmds: Whether to require approval for `!` shell
-                commands. When enabled, each shell command triggers an
-                approval request before execution.
+                commands and `%%bash`/`%%sh` cell magics. When enabled,
+                each shell command triggers an approval request before
+                execution.
             require_shell_escape: Whether to block direct process-creation
                 calls (`subprocess`, `os.system`, `os.exec*`, `os.spawn*`,
                 `os.posix_spawn*`, `pty.spawn`), forcing shell commands
-                through the `!` handler. Requires `approve_shell_cmds=True`.
+                through the `!` handler or `%%bash`/`%%sh` cell magics.
+                Requires `approve_shell_cmds=True`.
             tool_server_host: Hostname of the tool server (used when
                 `approve_shell_cmds` is `True`).
             tool_server_port: Port of the tool server (used when

--- a/ipybox/kernel_mgr/init.py
+++ b/ipybox/kernel_mgr/init.py
@@ -25,8 +25,10 @@ del _ipybox_cwd, _ipybox_restore_cwd
 
 _SHELL_ESCAPE_GUARD = """\
 from contextvars import ContextVar as _ContextVar
+import threading as _threading
 _ipybox_shell_allowed = _ContextVar('_ipybox_shell_allowed', default=False)
-del _ContextVar
+_ipybox_magic_allowed = _threading.Event()
+del _ContextVar, _threading
 """
 
 _HANDLER_INSTALL = """\
@@ -48,13 +50,13 @@ import subprocess as _subprocess
 _ipybox_orig_popen = _subprocess.Popen
 class _ipybox_guarded_popen(_ipybox_orig_popen):
     def __init__(self, *args, **kwargs):
-        if not _ipybox_shell_allowed.get():
+        if not _ipybox_shell_allowed.get() and not _ipybox_magic_allowed.is_set():
             raise RuntimeError('Direct subprocess calls are not allowed. Use ! syntax.')
         super().__init__(*args, **kwargs)
 _subprocess.Popen = _ipybox_guarded_popen
 _ipybox_orig_os_system = _os.system
 def _ipybox_guarded_os_system(cmd):
-    if not _ipybox_shell_allowed.get():
+    if not _ipybox_shell_allowed.get() and not _ipybox_magic_allowed.is_set():
         raise RuntimeError('Direct os.system() calls are not allowed. Use ! syntax.')
     return _ipybox_orig_os_system(cmd)
 _os.system = _ipybox_guarded_os_system
@@ -66,7 +68,7 @@ for _ipybox_name in ('execv', 'execve', 'execl', 'execle', 'execvp', 'execvpe', 
     if hasattr(_os, _ipybox_name):
         _ipybox_orig = getattr(_os, _ipybox_name)
         def _ipybox_guard(*args, _orig=_ipybox_orig, _name=_ipybox_name, **kwargs):
-            if not _ipybox_shell_allowed.get():
+            if not _ipybox_shell_allowed.get() and not _ipybox_magic_allowed.is_set():
                 raise RuntimeError(f'Direct os.{_name}() calls are not allowed. Use ! syntax.')
             return _orig(*args, **kwargs)
         setattr(_os, _ipybox_name, _ipybox_guard)
@@ -75,7 +77,7 @@ try:
     import pty as _pty
     _ipybox_orig_pty_spawn = _pty.spawn
     def _ipybox_guarded_pty_spawn(*args, **kwargs):
-        if not _ipybox_shell_allowed.get():
+        if not _ipybox_shell_allowed.get() and not _ipybox_magic_allowed.is_set():
             raise RuntimeError('Direct pty.spawn() calls are not allowed. Use ! syntax.')
         return _ipybox_orig_pty_spawn(*args, **kwargs)
     _pty.spawn = _ipybox_guarded_pty_spawn
@@ -102,6 +104,34 @@ finally:
     _ipybox_shell_allowed.set(False)
 """
 
+_BASH_MAGIC_HANDLER = """\
+from mcpygen import ApprovalRequestor as _AR
+_AR('ipybox', {host!r}, {port}).request_sync('shell', {{'cmd': cell}})
+return _orig(line, cell)
+"""
+
+_BASH_MAGIC_HANDLER_ESCAPE = """\
+from mcpygen import ApprovalRequestor as _AR
+_AR('ipybox', {host!r}, {port}).request_sync('shell', {{'cmd': cell}})
+_ipybox_magic_allowed.set()
+try:
+    return _orig(line, cell)
+finally:
+    _ipybox_magic_allowed.clear()
+"""
+
+_BASH_MAGIC_INSTALL = """\
+_ipybox_cell_magics = get_ipython().magics_manager.magics['cell']
+_ipybox_magic_wrapper = None
+for _ipybox_magic_name in ('bash', 'sh'):
+    _ipybox_orig_magic = _ipybox_cell_magics.get(_ipybox_magic_name)
+    if _ipybox_orig_magic is not None:
+        def _ipybox_magic_wrapper(line, cell, _orig=_ipybox_orig_magic):
+{handler_body}
+        _ipybox_cell_magics[_ipybox_magic_name] = _ipybox_magic_wrapper
+del _ipybox_cell_magics, _ipybox_magic_name, _ipybox_orig_magic, _ipybox_magic_wrapper
+"""
+
 _TERMINAL_ENV = """\
 _os.environ['TERM'] = 'dumb'
 _os.environ['NO_COLOR'] = '1'
@@ -122,7 +152,8 @@ def build_init_code(
     Args:
         working_dir: Working directory to restore after each cell execution.
         approve_shell_cmds: Whether to require approval for `!` shell
-            commands via `ApprovalRequestor`.
+            commands and `%%bash`/`%%sh` cell magics via
+            `ApprovalRequestor`.
         require_shell_escape: Whether to block direct process-creation
             calls (`subprocess`, `os.system`, `os.exec*`, `os.spawn*`,
             `os.posix_spawn*`, `pty.spawn`), forcing shell commands
@@ -141,10 +172,14 @@ def build_init_code(
         if require_shell_escape:
             parts.append(_SHELL_ESCAPE_GUARD)
             handler = _APPROVAL_HANDLER_ESCAPE.format(host=tool_server_host, port=tool_server_port)
+            magic_handler = _BASH_MAGIC_HANDLER_ESCAPE.format(host=tool_server_host, port=tool_server_port)
         else:
             handler = _APPROVAL_HANDLER.format(host=tool_server_host, port=tool_server_port)
+            magic_handler = _BASH_MAGIC_HANDLER.format(host=tool_server_host, port=tool_server_port)
         handler_body = textwrap.indent(handler.strip(), "    ")
         parts.append(_HANDLER_INSTALL.format(handler_body=handler_body))
+        magic_handler_body = textwrap.indent(magic_handler.strip(), " " * 12)
+        parts.append(_BASH_MAGIC_INSTALL.format(handler_body=magic_handler_body))
         if require_shell_escape:
             parts.append(_SUBPROCESS_GUARD)
 

--- a/tests/integration/test_shell_cmds.py
+++ b/tests/integration/test_shell_cmds.py
@@ -106,6 +106,98 @@ class TestApproveShellCmds:
             assert "NameError" in str(exc_info.value)
 
     @pytest.mark.asyncio
+    async def test_bash_magic_triggers_approval(self, executor_approve: CodeExecutor):
+        approvals = []
+        async for item in executor_approve.stream("%%bash\necho hello"):
+            match item:
+                case ApprovalRequest():
+                    approvals.append(item)
+                    await item.accept()
+                case CodeExecutionResult():
+                    result = item
+
+        assert len(approvals) == 1
+        assert approvals[0].tool_name == "shell"
+        assert "echo hello" in approvals[0].tool_args["cmd"]
+        assert result.text is not None
+        assert "hello" in result.text
+
+    @pytest.mark.asyncio
+    async def test_sh_magic_triggers_approval(self, executor_approve: CodeExecutor):
+        approvals = []
+        async for item in executor_approve.stream("%%sh\necho hello"):
+            match item:
+                case ApprovalRequest():
+                    approvals.append(item)
+                    await item.accept()
+                case CodeExecutionResult():
+                    result = item
+
+        assert len(approvals) == 1
+        assert approvals[0].tool_name == "shell"
+        assert "echo hello" in approvals[0].tool_args["cmd"]
+        assert result.text is not None
+        assert "hello" in result.text
+
+    @pytest.mark.asyncio
+    async def test_bash_magic_multiline(self, executor_approve: CodeExecutor):
+        code = "%%bash\necho line1\necho line2"
+        approvals = []
+        async for item in executor_approve.stream(code):
+            match item:
+                case ApprovalRequest():
+                    approvals.append(item)
+                    await item.accept()
+                case CodeExecutionResult():
+                    result = item
+
+        assert len(approvals) == 1
+        assert "echo line1" in approvals[0].tool_args["cmd"]
+        assert "echo line2" in approvals[0].tool_args["cmd"]
+        assert result.text is not None
+        assert "line1" in result.text
+        assert "line2" in result.text
+
+    @pytest.mark.asyncio
+    async def test_bash_magic_rejection(self, executor_approve: CodeExecutor):
+        with pytest.raises(CodeExecutionError) as exc_info:
+            async for item in executor_approve.stream("%%bash\necho secret"):
+                match item:
+                    case ApprovalRequest():
+                        await item.reject()
+
+        assert "Rejected" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_bash_magic_with_python_before_is_syntax_error(self, executor_approve: CodeExecutor):
+        code = "x = 42\n%%bash\necho hello"
+        with pytest.raises(CodeExecutionError) as exc_info:
+            await executor_approve.execute(code)
+        assert "SyntaxError" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_bash_magic_body_is_not_python(self, executor_approve: CodeExecutor):
+        code = "%%bash\necho hello\nprint('python')"
+        with pytest.raises(CodeExecutionError) as exc_info:
+            async for item in executor_approve.stream(code):
+                match item:
+                    case ApprovalRequest():
+                        await item.accept()
+        assert "CalledProcessError" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_init_does_not_leak_magic_variables(self, executor_approve: CodeExecutor):
+        for name in (
+            "_ipybox_cell_magics",
+            "_ipybox_magic_name",
+            "_ipybox_orig_magic",
+            "_ipybox_magic_wrapper",
+        ):
+            with pytest.raises(CodeExecutionError) as exc_info:
+                await executor_approve.execute(f"print({name})")
+            assert "NameError" in str(exc_info.value)
+
+    @pytest.mark.asyncio
     async def test_shell_cmd_rejection(self, executor_approve: CodeExecutor):
         with pytest.raises(CodeExecutionError) as exc_info:
             async for item in executor_approve.stream("!echo secret"):
@@ -187,6 +279,36 @@ class TestRequireShellEscape:
         assert len(approvals) == 1
         assert result.text is not None
         assert "hello" in result.text
+
+    @pytest.mark.asyncio
+    async def test_bash_magic_still_works(self, executor_escape: CodeExecutor):
+        approvals = []
+        async for item in executor_escape.stream("%%bash\necho hello"):
+            match item:
+                case ApprovalRequest():
+                    approvals.append(item)
+                    await item.accept()
+                case CodeExecutionResult():
+                    result = item
+
+        assert len(approvals) == 1
+        assert result.text is not None
+        assert "hello" in result.text
+
+    @pytest.mark.asyncio
+    async def test_bash_magic_does_not_leak_allowed_state(self, executor_escape: CodeExecutor):
+        # First, run an approved %%bash to set/clear the magic_allowed event
+        async for item in executor_escape.stream("%%bash\necho ok"):
+            match item:
+                case ApprovalRequest():
+                    await item.accept()
+                case CodeExecutionResult():
+                    pass
+
+        # Then verify subprocess.run is still blocked
+        with pytest.raises(CodeExecutionError) as exc_info:
+            await executor_escape.execute('import subprocess; subprocess.run(["echo", "hi"])')
+        assert "Direct subprocess calls are not allowed" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_init_does_not_leak_guard_variables(self, executor_escape: CodeExecutor):

--- a/tests/unit/test_kernel_init.py
+++ b/tests/unit/test_kernel_init.py
@@ -172,9 +172,6 @@ class TestBuildInitCodeBashMagic:
             tool_server_host="myhost",
             tool_server_port=9999,
         )
-        # The magic handler section should also contain ApprovalRequestor
-        # with the correct host/port (already covered by the shell handler,
-        # but verify it appears in the magic wrapper context too)
         assert "_ipybox_magic_wrapper" in code
         assert "ApprovalRequestor" in code
 

--- a/tests/unit/test_kernel_init.py
+++ b/tests/unit/test_kernel_init.py
@@ -152,3 +152,56 @@ class TestBuildInitCodeShellEscape:
         code = build_init_code(require_shell_escape=True)
         assert "_ipybox_shell_allowed" not in code
         assert "_ipybox_guarded_popen" not in code
+
+    def test_subprocess_guard_checks_magic_allowed(self):
+        code = build_init_code(approve_shell_cmds=True, require_shell_escape=True)
+        assert "_ipybox_magic_allowed.is_set()" in code
+
+
+class TestBuildInitCodeBashMagic:
+    """Tests for the %%bash/%%sh cell magic approval handler."""
+
+    def test_installs_magic_wrapper(self):
+        code = build_init_code(approve_shell_cmds=True)
+        assert "_ipybox_magic_wrapper" in code
+        assert "_ipybox_cell_magics" in code
+
+    def test_magic_handler_contains_approval_requestor(self):
+        code = build_init_code(
+            approve_shell_cmds=True,
+            tool_server_host="myhost",
+            tool_server_port=9999,
+        )
+        # The magic handler section should also contain ApprovalRequestor
+        # with the correct host/port (already covered by the shell handler,
+        # but verify it appears in the magic wrapper context too)
+        assert "_ipybox_magic_wrapper" in code
+        assert "ApprovalRequestor" in code
+
+    def test_magic_handler_calls_orig(self):
+        code = build_init_code(approve_shell_cmds=True)
+        assert "return _orig(line, cell)" in code
+
+    def test_iterates_bash_and_sh(self):
+        code = build_init_code(approve_shell_cmds=True)
+        assert "'bash'" in code
+        assert "'sh'" in code
+
+    def test_cleans_up_magic_variables(self):
+        code = build_init_code(approve_shell_cmds=True)
+        assert "del _ipybox_cell_magics, _ipybox_magic_name, _ipybox_orig_magic, _ipybox_magic_wrapper" in code
+
+    def test_no_magic_handler_by_default(self):
+        code = build_init_code()
+        assert "_ipybox_magic_wrapper" not in code
+        assert "_ipybox_cell_magics" not in code
+
+    def test_escape_sets_magic_allowed(self):
+        code = build_init_code(approve_shell_cmds=True, require_shell_escape=True)
+        assert "_ipybox_magic_allowed.set()" in code
+        assert "_ipybox_magic_allowed.clear()" in code
+
+    def test_escape_uses_threading_event(self):
+        code = build_init_code(approve_shell_cmds=True, require_shell_escape=True)
+        assert "threading" in code
+        assert "_ipybox_magic_allowed" in code

--- a/tests/unit/test_rewrite_traceback.py
+++ b/tests/unit/test_rewrite_traceback.py
@@ -35,3 +35,13 @@ class TestRewriteTraceback:
 
     def test_empty_input(self):
         assert KernelClient._rewrite_traceback([]) == []
+
+    def test_replaces_run_cell_magic_with_double_percent(self):
+        entries = ["get_ipython().run_cell_magic('bash', '', 'echo hello\\n')"]
+        result = KernelClient._rewrite_traceback(entries)
+        assert result == ["%%bash\necho hello\\n"]
+
+    def test_replaces_sh_cell_magic(self):
+        entries = ["get_ipython().run_cell_magic('sh', '', 'ls -la\\n')"]
+        result = KernelClient._rewrite_traceback(entries)
+        assert result == ["%%sh\nls -la\\n"]


### PR DESCRIPTION
Intercept %%bash and %%sh cell magics for approval when
approve_shell_cmds=True, using the same approval flow as !cmd.
Uses threading.Event for the require_shell_escape subprocess guard
since IPython 9.x runs cell magic subprocesses on a background thread
where ContextVar does not propagate.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
