### PR TITLE
Use shell_magic tool_name for %%bash/%%sh approval requests

### DIFF
--- a/docs/codeexec.md
+++ b/docs/codeexec.md
@@ -64,7 +64,7 @@ Enable `approve_shell_cmds=True` to require application-level approval for shell
 
 Each `!cmd` triggers an `ApprovalRequest` with `tool_name="shell"` and `tool_args={"cmd": "..."}`, using the same approval interface as tool calls. Variable interpolation happens before the approval request, so the application sees the fully expanded command.
 
-`%%bash` and `%%sh` cell magics also trigger approval when `approve_shell_cmds=True`. The `tool_args["cmd"]` contains the cell body:
+`%%bash` and `%%sh` cell magics also trigger approval when `approve_shell_cmds=True`, with `tool_name="shell_magic"` and `tool_args={"cmd": "..."}` containing the cell body:
 
 ```python
 --8<-- "examples/codexec.py:bash_magic_approval"

--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -51,7 +51,7 @@ The following modules have been extracted to the [mcpygen](https://github.com/gr
 
 1. `%%bash` or `%%sh` triggers magic wrapper installed by `build_init_code()`
 2. Wrapper -> `ApprovalRequestor` -> ToolServer -> `ApprovalClient`
-3. Application receives `ApprovalRequest(tool_name="shell", tool_args={"cmd": "<cell body>"})`
+3. Application receives `ApprovalRequest(tool_name="shell_magic", tool_args={"cmd": "<cell body>"})`
 4. If accepted: wrapper calls original magic, which runs the script via `asyncio.create_subprocess_exec` on a background thread
 5. `require_shell_escape=True`: a `threading.Event` (`_ipybox_magic_allowed`) is used instead of `ContextVar` because IPython 9.x runs the subprocess on a background thread where `ContextVar` does not propagate. The event is set before calling the original magic and cleared in a `finally` block. Subprocess guards check both the `ContextVar` and the event.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -72,7 +72,7 @@ The following example executes a code block that calls an MCP tool and runs a sh
 --8<-- "examples/quickstart.py:approval"
 ```
 
-Both approval types yield an `ApprovalRequest`. The `tool_name` field distinguishes them: `"shell"` for shell commands, the MCP tool name for tool calls. Call `accept()` to continue or `reject()` to block execution.
+Both approval types yield an `ApprovalRequest`. The `tool_name` field distinguishes them: `"shell"` for `!` commands, `"shell_magic"` for `%%bash`/`%%sh` cell magics, and the MCP tool name for tool calls. Call `accept()` to continue or `reject()` to block execution.
 
 ## Next steps
 

--- a/examples/codexec.py
+++ b/examples/codexec.py
@@ -190,7 +190,7 @@ async def bash_magic_approval():
     async with CodeExecutor(approve_shell_cmds=True) as executor:
         async for item in executor.stream(code):
             match item:
-                case ApprovalRequest(tool_name="shell", tool_args=args):
+                case ApprovalRequest(tool_name="shell_magic", tool_args=args):
                     assert "echo hello from bash" in args["cmd"]
                     await item.accept()
                 case CodeExecutionResult():

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -90,7 +90,7 @@ async def approval():
     ) as executor:
         async for item in executor.stream(SEARCH_AND_ECHO):
             match item:
-                case ApprovalRequest(tool_name="shell", tool_args=args):
+                case ApprovalRequest(tool_name="shell" | "shell_magic", tool_args=args):
                     print(f"Shell: {args['cmd']}")
                     await item.accept()
                 case ApprovalRequest(tool_name=name, tool_args=args):

--- a/ipybox/kernel_mgr/init.py
+++ b/ipybox/kernel_mgr/init.py
@@ -106,13 +106,13 @@ finally:
 
 _BASH_MAGIC_HANDLER = """\
 from mcpygen import ApprovalRequestor as _AR
-_AR('ipybox', {host!r}, {port}).request_sync('shell', {{'cmd': cell}})
+_AR('ipybox', {host!r}, {port}).request_sync('shell_magic', {{'cmd': cell}})
 return _orig(line, cell)
 """
 
 _BASH_MAGIC_HANDLER_ESCAPE = """\
 from mcpygen import ApprovalRequestor as _AR
-_AR('ipybox', {host!r}, {port}).request_sync('shell', {{'cmd': cell}})
+_AR('ipybox', {host!r}, {port}).request_sync('shell_magic', {{'cmd': cell}})
 _ipybox_magic_allowed.set()
 try:
     return _orig(line, cell)

--- a/tests/integration/test_shell_cmds.py
+++ b/tests/integration/test_shell_cmds.py
@@ -117,7 +117,7 @@ class TestApproveShellCmds:
                     result = item
 
         assert len(approvals) == 1
-        assert approvals[0].tool_name == "shell"
+        assert approvals[0].tool_name == "shell_magic"
         assert "echo hello" in approvals[0].tool_args["cmd"]
         assert result.text is not None
         assert "hello" in result.text
@@ -134,7 +134,7 @@ class TestApproveShellCmds:
                     result = item
 
         assert len(approvals) == 1
-        assert approvals[0].tool_name == "shell"
+        assert approvals[0].tool_name == "shell_magic"
         assert "echo hello" in approvals[0].tool_args["cmd"]
         assert result.text is not None
         assert "hello" in result.text


### PR DESCRIPTION
## Summary

- `%%bash`/`%%sh` cell magic approval requests now use `tool_name="shell_magic"` instead of `"shell"`, letting consumers distinguish them from `!` shell escape commands and apply different approval policies
- `!` shell commands continue to use `tool_name="shell"`
- Updated docs, examples, and tests to reflect the new tool name

🤖 Generated with [Claude Code](https://claude.com/claude-code)