### PR TITLE
Make kernel-init timeout configurable (#55)

### DIFF
--- a/docs/internal/testing.md
+++ b/docs/internal/testing.md
@@ -16,12 +16,13 @@
 - `test_code_exec_helpers.py`: execution budget, stream worker
 - `test_kernel_gateway.py`: KernelGateway subprocess configuration
 - `test_kernel_init.py`: `build_init_code()` output sections and variable cleanup
+- `test_kernel_init_timeout.py`: `kernel_init_timeout` wiring through KernelClient and CodeExecutor
 - `test_rewrite_traceback.py`: `_ipybox_` filtering, `get_ipython().system()` rewriting
 
 ## Integration tests
 
 - `test_code_exec.py`: CodeExecutor end-to-end (execution, streaming, approval, rejection, timeouts)
-- `test_kernel_init.py`: ANSI stripping, variable cleanup
+- `test_kernel_init.py`: ANSI stripping, variable cleanup, `kernel_init_timeout` behavior
 - `test_kernel_mgr.py`: KernelClient and KernelGateway integration
 - `test_shell_cmds.py`: shell command approval and subprocess blocking
 - `test_mcp_server.py`: MCPServer functionality

--- a/ipybox/code_exec.py
+++ b/ipybox/code_exec.py
@@ -103,6 +103,7 @@ class CodeExecutor:
         images_dir: Path | None = None,
         approval_timeout: float | None = None,
         connect_timeout: float = 30,
+        kernel_init_timeout: float = 10,
         sandbox: bool = False,
         sandbox_config: Path | None = None,
         log_level: str = "WARNING",
@@ -133,6 +134,10 @@ class CodeExecutor:
                 approval request is not accepted or rejected within this time,
                 the tool call fails. If `None`, no timeout is applied.
             connect_timeout: Timeout in seconds for starting MCP servers.
+            kernel_init_timeout: Maximum time in seconds to wait for IPython
+                kernel initialization to complete during startup. Raise this if
+                kernel startup intermittently times out under load, for example
+                on busy CI runners or when many executors start in parallel.
             sandbox: Whether to run the kernel gateway inside Anthropic's
                 [sandbox-runtime](https://github.com/anthropic-experimental/sandbox-runtime).
                 When enabled, IPython kernels run in a secure sandbox with no
@@ -171,6 +176,7 @@ class CodeExecutor:
 
         self.approval_timeout = approval_timeout
         self.connect_timeout = connect_timeout
+        self.kernel_init_timeout = kernel_init_timeout
 
         self.sandbox = sandbox
         self.sandbox_config = sandbox_config
@@ -377,6 +383,7 @@ class CodeExecutor:
                     require_shell_escape=self.require_shell_escape,
                     tool_server_host=self.tool_server_host,
                     tool_server_port=self.tool_server_port,
+                    kernel_init_timeout=self.kernel_init_timeout,
                 ) as client:
                     yield client
 

--- a/ipybox/kernel_mgr/client.py
+++ b/ipybox/kernel_mgr/client.py
@@ -74,6 +74,7 @@ class KernelClient:
         require_shell_escape: bool = False,
         tool_server_host: str = "localhost",
         tool_server_port: int = 0,
+        kernel_init_timeout: float = 10,
     ):
         """
         Args:
@@ -99,6 +100,12 @@ class KernelClient:
                 `approve_shell_cmds` is `True`).
             tool_server_port: Port of the tool server (used when
                 `approve_shell_cmds` is `True`).
+            kernel_init_timeout: Maximum time in seconds to wait for kernel
+                initialization to complete during
+                [`connect`][ipybox.kernel_mgr.client.KernelClient.connect].
+                Raise this if kernel startup intermittently times out under
+                load, for example on busy CI runners or when many kernels
+                start in parallel. Can be overridden per call via `connect`.
         """
         self.host = host
         self.port = port
@@ -110,6 +117,7 @@ class KernelClient:
         self.require_shell_escape = require_shell_escape
         self.tool_server_host = tool_server_host
         self.tool_server_port = tool_server_port
+        self.kernel_init_timeout = kernel_init_timeout
 
         self._kernel_id: str | None = None
         self._session_id: str | None = None
@@ -145,15 +153,20 @@ class KernelClient:
     def kernel_ws_url(self):
         return f"ws://{self.host}:{self.port}/api/kernels/{self.kernel_id}/channels?session_id={self._session_id}"
 
-    async def connect(self, retries: int = 10, retry_interval: float = 1.0):
+    async def connect(self, retries: int = 10, retry_interval: float = 1.0, kernel_init_timeout: float | None = None):
         """Creates an IPython kernel and connects to it.
 
         Args:
             retries: Number of connection retries.
             retry_interval: Delay between connection retries in seconds.
+            kernel_init_timeout: Maximum time in seconds to wait for kernel
+                initialization to complete. If `None`, the `kernel_init_timeout`
+                configured in the constructor is used.
 
         Raises:
             RuntimeError: If connection cannot be established after all retries.
+            asyncio.TimeoutError: If kernel initialization does not complete
+                within `kernel_init_timeout`.
         """
         for _ in range(retries):
             try:
@@ -177,7 +190,7 @@ class KernelClient:
         # timeout during _init_kernel
         await asyncio.sleep(0.2)
 
-        await self._init_kernel()
+        await self._init_kernel(kernel_init_timeout)
 
     async def disconnect(self):
         """Disconnects from and deletes the running IPython kernel."""
@@ -377,7 +390,7 @@ class KernelClient:
         await asyncio.sleep(settle_delay)
         await self.drain(timeout=drain_timeout)
 
-    async def _init_kernel(self):
+    async def _init_kernel(self, timeout: float | None = None):
         code = build_init_code(
             working_dir=self.working_dir,
             approve_shell_cmds=self.approve_shell_cmds,
@@ -385,7 +398,7 @@ class KernelClient:
             tool_server_host=self.tool_server_host,
             tool_server_port=self.tool_server_port,
         )
-        await self.execute(code, timeout=10)
+        await self.execute(code, timeout=timeout if timeout is not None else self.kernel_init_timeout)
 
     def _raise_error(self, msg_dict):
         error_name = msg_dict["content"].get("ename", "Unknown Error")

--- a/tests/integration/test_kernel_init.py
+++ b/tests/integration/test_kernel_init.py
@@ -1,5 +1,6 @@
 """Tests for kernel initialization behavior."""
 
+import asyncio
 import re
 
 import pytest
@@ -76,3 +77,35 @@ class TestKernelInitialization:
             with pytest.raises(ExecutionError) as exc_info:
                 await client_with_working_dir.execute(f"print({name})")
             assert "NameError" in str(exc_info.value)
+
+
+class TestKernelInitTimeout:
+    @pytest.mark.asyncio
+    async def test_connect_succeeds_with_constructor_timeout(self, gateway, tmp_path):
+        async with KernelClient(
+            host=gateway.host,
+            port=gateway.port,
+            images_dir=tmp_path / "images",
+            kernel_init_timeout=60,
+        ) as client:
+            assert client.kernel_init_timeout == 60
+            result = await client.execute("print('ok')")
+            assert result.text == "ok"
+
+    @pytest.mark.asyncio
+    async def test_connect_times_out_with_tiny_constructor_timeout(self, gateway):
+        client = KernelClient(host=gateway.host, port=gateway.port, kernel_init_timeout=0.001)
+        try:
+            with pytest.raises(asyncio.TimeoutError):
+                await client.connect()
+        finally:
+            await client.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_connect_argument_overrides_constructor_timeout(self, gateway):
+        client = KernelClient(host=gateway.host, port=gateway.port, kernel_init_timeout=60)
+        try:
+            with pytest.raises(asyncio.TimeoutError):
+                await client.connect(kernel_init_timeout=0.001)
+        finally:
+            await client.disconnect()

--- a/tests/unit/test_kernel_init_timeout.py
+++ b/tests/unit/test_kernel_init_timeout.py
@@ -1,0 +1,108 @@
+"""Unit tests for the configurable kernel initialization timeout."""
+
+import pytest
+
+from ipybox.code_exec import CodeExecutor
+from ipybox.kernel_mgr.client import KernelClient
+
+
+class TestKernelClientInitTimeout:
+    """Tests for `KernelClient.kernel_init_timeout` wiring."""
+
+    def test_default_value(self):
+        client = KernelClient()
+        assert client.kernel_init_timeout == 10
+
+    def test_constructor_value_is_stored(self):
+        client = KernelClient(kernel_init_timeout=45)
+        assert client.kernel_init_timeout == 45
+
+    @pytest.mark.asyncio
+    async def test_init_kernel_uses_configured_timeout(self, monkeypatch: pytest.MonkeyPatch):
+        client = KernelClient(kernel_init_timeout=42)
+
+        captured: dict[str, float | None] = {}
+
+        async def fake_execute(code: str, timeout: float | None = None):
+            captured["timeout"] = timeout
+
+        monkeypatch.setattr(client, "execute", fake_execute)
+
+        await client._init_kernel()
+        assert captured["timeout"] == 42
+
+    @pytest.mark.asyncio
+    async def test_init_kernel_explicit_timeout_overrides_constructor(self, monkeypatch: pytest.MonkeyPatch):
+        client = KernelClient(kernel_init_timeout=42)
+
+        captured: dict[str, float | None] = {}
+
+        async def fake_execute(code: str, timeout: float | None = None):
+            captured["timeout"] = timeout
+
+        monkeypatch.setattr(client, "execute", fake_execute)
+
+        await client._init_kernel(7)
+        assert captured["timeout"] == 7
+
+    @pytest.mark.asyncio
+    async def test_connect_threads_timeout_to_init_kernel(self, monkeypatch: pytest.MonkeyPatch):
+        client = KernelClient(kernel_init_timeout=42)
+
+        async def fake_create_kernel():
+            return "kernel-id"
+
+        async def fake_websocket_connect(*args: object, **kwargs: object):
+            return object()
+
+        captured: dict[str, float | None] = {}
+
+        async def fake_init_kernel(timeout: float | None = None):
+            captured["timeout"] = timeout
+
+        monkeypatch.setattr(client, "_create_kernel", fake_create_kernel)
+        monkeypatch.setattr("ipybox.kernel_mgr.client.websocket_connect", fake_websocket_connect)
+        monkeypatch.setattr(client, "_init_kernel", fake_init_kernel)
+
+        await client.connect(kernel_init_timeout=9)
+        assert captured["timeout"] == 9
+
+    @pytest.mark.asyncio
+    async def test_connect_without_override_passes_none(self, monkeypatch: pytest.MonkeyPatch):
+        client = KernelClient(kernel_init_timeout=42)
+
+        async def fake_create_kernel():
+            return "kernel-id"
+
+        async def fake_websocket_connect(*args: object, **kwargs: object):
+            return object()
+
+        captured: dict[str, float | None] = {}
+
+        async def fake_init_kernel(timeout: float | None = None):
+            captured["timeout"] = timeout
+
+        monkeypatch.setattr(client, "_create_kernel", fake_create_kernel)
+        monkeypatch.setattr("ipybox.kernel_mgr.client.websocket_connect", fake_websocket_connect)
+        monkeypatch.setattr(client, "_init_kernel", fake_init_kernel)
+
+        await client.connect()
+        # None falls back to the constructor value inside _init_kernel.
+        assert captured["timeout"] is None
+
+
+class TestCodeExecutorInitTimeout:
+    """Tests for `CodeExecutor.kernel_init_timeout` wiring."""
+
+    def test_default_value(self):
+        executor = CodeExecutor()
+        assert executor.kernel_init_timeout == 10
+
+    def test_constructor_value_is_stored(self):
+        executor = CodeExecutor(kernel_init_timeout=45)
+        assert executor.kernel_init_timeout == 45
+
+    def test_independent_of_connect_timeout(self):
+        executor = CodeExecutor(connect_timeout=15, kernel_init_timeout=60)
+        assert executor.connect_timeout == 15
+        assert executor.kernel_init_timeout == 60


### PR DESCRIPTION
## Problem

`KernelClient._init_kernel` ran the kernel bootstrap code with a hardcoded `await self.execute(code, timeout=10)`. That 10s budget is the only window for the kernel to stream back its init result, and under load (CI runners, many kernels/gateways starting in parallel) it is too tight. When exceeded, the `asyncio.timeout(10)` in `stream()` fires, the websocket read is cancelled, and the resulting `TimeoutError` propagates out of `connect()`, aborting `CodeExecutor` startup. There was no public knob to widen it (`connect_timeout` is the unrelated MCP/ToolServer timeout).

This is the upstream root cause of the flaky startup in freeact (gradion-ai/freeact#98).

## Change

- Add `kernel_init_timeout: float = 10` to `KernelClient.__init__`; `_init_kernel` uses it instead of the literal `10`.
- Allow per-call override via `connect(kernel_init_timeout=...)`, alongside the existing `retries` / `retry_interval`; `None` falls back to the constructor value.
- Thread `kernel_init_timeout: float = 10` through `CodeExecutor.__init__` so downstream apps can configure it.

The default stays at the previous hardcoded `10`, so **default behavior is unchanged** — this PR only exposes the knob. Apps that hit slow-but-healthy kernel startup under load can now raise it (e.g. freeact would surface it as a config field) without monkeypatching internals.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)